### PR TITLE
Update setuppt2.sh

### DIFF
--- a/setuppt2.sh
+++ b/setuppt2.sh
@@ -29,9 +29,6 @@ read -p "Target Config (ex: makerlab-3040) " config
   nixos-install --flake /mnt/etc/nixos#$config
 
   touch /mnt/root/setup.toml
-  echo config=$config >> /mnt/root/setup.toml
-  
-  echo "Finishing touches"
-  echo hostname=$1 >> /mnt/root/setup.toml
+  echo config="$config" >> /mnt/root/setup.toml
   
   echo "Done, reboot."


### PR DESCRIPTION
added quotes to $config for setup.toml otherwise it is invalid toml

also removed hostname=$1 as we aren't passing arguments to the setup script