### PR TITLE
Himmelblau

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1768854600,
+        "lastModified": 1768923942,
         "narHash": "sha256-ZMfFqh6kzx0syKR7kN2MrM5F5W1FierlouTEgI8mbzY=",
-        "owner": "iLikeToCode",
+        "owner": "himmelblau-idm",
         "repo": "himmelblau",
-        "rev": "149e45fe76ba78b5259d0e4c1d4c2dc6ec30cb64",
+        "rev": "8237604a28db8f860510001b63d21d47058d72a8",
         "type": "github"
       },
       "original": {
-        "owner": "iLikeToCode",
-        "ref": "oidc_fix",
+        "owner": "himmelblau-idm",
         "repo": "himmelblau",
         "type": "github"
       }
@@ -28,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768836546,
-        "narHash": "sha256-nJZkTamcXXMW+SMYiGFB6lB8l0aJw0xjssfN8xYd/Fs=",
+        "lastModified": 1768927746,
+        "narHash": "sha256-zyMpWHqcpKVmRc1W2NEK7DAuyVJZV62Jdjqudg70b1k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b56c5ad14fcf8b5bc887463552483bf000ca562a",
+        "rev": "63a87808f5f9b6e4195a1d33f6ea25d23f4aa0df",
         "type": "github"
       },
       "original": {
@@ -43,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768621446,
-        "narHash": "sha256-6YwHV1cjv6arXdF/PQc365h1j+Qje3Pydk501Rm4Q+4=",
+        "lastModified": 1768773494,
+        "narHash": "sha256-XsM7GP3jHlephymxhDE+/TKKO1Q16phz/vQiLBGhpF4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72ac591e737060deab2b86d6952babd1f896d7c5",
+        "rev": "77ef7a29d276c6d8303aece3444d61118ef71ac2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "himmelblau": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768854600,
+        "narHash": "sha256-ZMfFqh6kzx0syKR7kN2MrM5F5W1FierlouTEgI8mbzY=",
+        "owner": "iLikeToCode",
+        "repo": "himmelblau",
+        "rev": "149e45fe76ba78b5259d0e4c1d4c2dc6ec30cb64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iLikeToCode",
+        "ref": "oidc_fix",
+        "repo": "himmelblau",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -7,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767898632,
-        "narHash": "sha256-ZpkiMJahNh5Xo1Lqxy2e2SEwyhWDwxrlv4zUO99OIrc=",
+        "lastModified": 1768836546,
+        "narHash": "sha256-nJZkTamcXXMW+SMYiGFB6lB8l0aJw0xjssfN8xYd/Fs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "40deed4ffe019874309b3eef429e4830346b0aa9",
+        "rev": "b56c5ad14fcf8b5bc887463552483bf000ca562a",
         "type": "github"
       },
       "original": {
@@ -22,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767799921,
-        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
+        "lastModified": 1768621446,
+        "narHash": "sha256-6YwHV1cjv6arXdF/PQc365h1j+Qje3Pydk501Rm4Q+4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
+        "rev": "72ac591e737060deab2b86d6952babd1f896d7c5",
         "type": "github"
       },
       "original": {
@@ -38,6 +59,7 @@
     },
     "root": {
       "inputs": {
+        "himmelblau": "himmelblau",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
-    himmelblau.url = "github:iLikeToCode/himmelblau/oidc_fix";
+    himmelblau.url = "github:himmelblau-idm/himmelblau";
     himmelblau.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,11 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    himmelblau.url = "github:iLikeToCode/himmelblau/oidc_fix";
+    himmelblau.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs =
-    { self, nixpkgs, home-manager, ... }@attrs:
+    { self, nixpkgs, home-manager, himmelblau, ... }@attrs:
     {
       nixosConfigurations = {
         makerlab = nixpkgs.lib.nixosSystem {

--- a/machines/MakerLab.nix
+++ b/machines/MakerLab.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  himmelblau,
   ...
 }:
 {
@@ -12,6 +13,7 @@
     ../programs/vscode.nix
     ../programs/python.nix
     ../programs/update-tool.nix
+    ../programs/himmelblau.nix
   ];
 
   users.users.makerlab = {

--- a/programs/cachix.nix
+++ b/programs/cachix.nix
@@ -12,9 +12,11 @@
     settings = {
       substituters = [
         "https://utcsheffield.cachix.org"
+        "https://himmelblau.cachix.org"
       ];
       trusted-public-keys = [
         "utcsheffield.cachix.org-1:JlnNbGhsj00NjGND1yb6SHRoM6JO2HjgrbhpqwAp8xo="
+        "himmelblau.cachix.org-1:yu8mq/NIBYsZHWzo4SOge97gpf02qugdZFT/JdRkswc="
       ];
     };
   };

--- a/programs/himmelblau.nix
+++ b/programs/himmelblau.nix
@@ -1,0 +1,13 @@
+{ himmelblau, ... }:
+
+{
+    imports = [ himmelblau.nixosModules.himmelblau ];
+    services.himmelblau = {
+        enable = true;
+        settings = {
+            oidc_issuer_url="tbc";
+            app_id="tbc";
+            shell = "/run/current-system/sw/bin/bash";
+        };
+    };
+}

--- a/programs/himmelblau.nix
+++ b/programs/himmelblau.nix
@@ -5,8 +5,8 @@
     services.himmelblau = {
         enable = true;
         settings = {
-            oidc_issuer_url="tbc";
-            app_id="tbc";
+            oidc_issuer_url="https://dev-a66o74ww13tx0ori.uk.auth0.com/";
+            app_id="ucjoleQifb1ifdCYLXeojZqcwgx7BzFF";
             shell = "/run/current-system/sw/bin/bash";
         };
     };


### PR DESCRIPTION
Fixes #35 

# Auth0 Setup Guide

---

### Enable Email Scope
* **Authentication** -> **Social** -> (app, e.g github)
* Scroll to **Permissions**, turn **Email address** on

---

### Add Auth0 'updated_at' claim fix
* **Actions** -> **Triggers** -> **Post Login**
* **Add Action** -> **Create Custom Action**
  * **Name:** fix updated_at claim
  * **Trigger:** Login / Post Login
  * **Runtime:** Node 22
* **Create**
* Replace code with:
```js
exports.onExecutePostLogin = async (event, api) => {
  if (event.client.name == "Makerlab Laptop") {
    api.idToken.setCustomClaim(
      "updated_at",
      Math.floor(new Date(event.user.updated_at).getTime() / 1000)
    );
  }
};
```

* **Deploy** -> **Back to Triggers**
* Drag action between **'Start'** and **'Complete'**
* **Apply**

---

### Setup Auth0 Application
* **Applications** -> **Applications** -> **Create Application**
  * **Name:** Makerlab Laptop
  * **NO PLURAL ^**
  * **Type:** Native
* **Settings** -> Collect **Client ID**
* Add the following **Redirect URL:**
  `himmelblau://Himmelblau.EntraId.BrokerPlugin`
* Scroll to **Refresh Token Expiration**
* Enable:
  * **Set Idle Refresh Token Lifetime**
  * **Set Maximum Refresh Token Lifetime**
  * **Allow Refresh Token Rotation**
* Scroll to **Advanced Settings** -> **Grant Types**
* Enable:
  * **Implicit**
  * **Authorization Code**
  * **Refresh Token**
  * **Device Code**
* Go to **Endpoints**
* Collect **OpenID Configuration** URL
* Scroll back up and switch to **Connections**
* Enable all connections wanted in login (e.g **Github** and **Gmail**)

In programs/himmelblau.nix, replace the two 'tbc' values with the respective values from auth0

Client ID as is into app_id
OIDC Issuer as OIDC Config URL minus '.well-known/openid-configuration'
e.g https://dev.uk.auth0.com/ (include the trailing /)